### PR TITLE
[Scala] fix memory leak for training, mnist example tested

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/ExecutorManager.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/ExecutorManager.scala
@@ -234,7 +234,8 @@ private[mxnet] object ExecutorManager {
 
   // Load a list of arrays into a list of arrays specified by slices
   private[mxnet] def loadGeneralMulti(data: Seq[NDArray],
-                                      targets: Seq[Array[(Int, Int, NDArray)]]): Unit = {
+                                      targets: Seq[Array[(Int, Int, NDArray)]])
+  : Unit = NDArrayCollector.auto().withScope {
     for ((src, dTargets) <- data zip targets) {
       for ((start, end, dst) <- dTargets) {
         val sliced = src.slice(start, end)
@@ -522,7 +523,8 @@ private class DataParallelExecutorGroup private(sym: Symbol,
   }
 
   // Update evaluation metric with label and current outputs
-  def updateMetric(metric: EvalMetric, labels: IndexedSeq[NDArray]): Unit = {
+  def updateMetric(metric: EvalMetric, labels: IndexedSeq[NDArray])
+  : Unit = NDArrayCollector.auto().withScope {
     (trainExecs zip slices).foreach { case (texec, islice) =>
       val labelsSlice = labels.map(_.slice(islice))
       metric.update(labelsSlice, texec.outputs)

--- a/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
@@ -160,6 +160,13 @@ class FeedForward private(
       }
     }
 
+    if (_argParams != null) {
+      _argParams.values.foreach(_.dispose())
+    }
+    if (_auxParams != null) {
+      _auxParams.values.foreach(_.dispose())
+    }
+
     _argParams = argParams
     _auxParams = auxParams
     (argNames, paramNames, auxNames)

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Model.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Model.scala
@@ -319,6 +319,8 @@ object Model {
           if (epochSize != -1 && nBatch >= epochSize) {
             doReset = false
           }
+
+          dataBatch.dispose()
         }
         if (doReset) {
           trainData.reset()
@@ -344,6 +346,7 @@ object Model {
           executorManager.loadDataBatch(evalBatch)
           executorManager.forward(isTrain = false)
           executorManager.updateMetric(evalMetric, evalBatch.label)
+          evalBatch.dispose()
         }
 
         val (name, value) = evalMetric.get

--- a/scala-package/core/src/main/scala/org/apache/mxnet/io/MXDataIter.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/io/MXDataIter.scala
@@ -45,7 +45,6 @@ private[mxnet] class MXDataIter(private[mxnet] val handle: DataIterHandle,
                _provideLabel: ListMap[String, Shape],
                _batchSize: Int) =
     if (hasNext) {
-      iterNext()
       val data = currentBatch.data(0)
       val label = currentBatch.label(0)
       // properties


### PR DESCRIPTION
```bash
java -Dmxnet.traceLeakedObjects=true -cp assembly/osx-x86_64-cpu/target/mxnet-full_2.11-osx-x86_64-cpu-1.3.0-SNAPSHOT.jar:examplarget/mxnet-examples_2.11-1.3.0-SNAPSHOT.jar:/Users/yizhiliu/Workspace/mxnet-java-example/target/lib/slf4j-simple-1.6.6.jar org.apache.mxnetexamples.imclassification.TrainMnist --data-dir /Users/yizhiliu/Workspace/mxnet/scala-package/core/data/
```

Before:
[mnist_origin.log.gz](https://github.com/yzhliu/mxnet/files/2195942/mnist_origin.log.gz)

After:
[mnist_auto_dispose.log](https://github.com/yzhliu/mxnet/files/2195944/mnist_auto_dispose.log)


